### PR TITLE
Fix  uncaught exception

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -387,7 +387,7 @@ var Protocol = {
         if (!(data instanceof Buffer)) {
             throw new TypeError('argument \'elem\' must be an instance of Buffer');
         }
-        if (!data) {
+        if (data.length === 0) {
             return;
         }
 

--- a/tests/protocol.js
+++ b/tests/protocol.js
@@ -262,7 +262,7 @@ describe('binrpc.decodeData(elem)', function () {
         }).should.throw();
     });
     it('should return undefined if Buffer is empty', function () {
-        let res = binrpc.decodeData(Buffer.from([]));
+        var res = binrpc.decodeData(Buffer.from([]));
         (typeof res).should.equal('undefined');
     });
 });

--- a/tests/protocol.js
+++ b/tests/protocol.js
@@ -261,6 +261,10 @@ describe('binrpc.decodeData(elem)', function () {
             binrpc.decodeData('string');
         }).should.throw();
     });
+    it('should return undefined if Buffer is empty', function () {
+        let res = binrpc.decodeData(Buffer.from([]));
+        (typeof res).should.equal('undefined');
+    });
 });
 
 describe('binrpc.decodeResponse(elem)', function () {


### PR DESCRIPTION
I created this fix to use homematic-manager with homegear.
The test of data in lib/protocol.js, line 390, will never be true, because the test "instanceof" before will throw in that case.
I think the test with "data.length === 0" was intended.
With this change, the homematic-manager works with a connection to homegear and fixes [issue 55](https://github.com/hobbyquaker/homematic-manager/issues/55) for me.