### PR TITLE
Fix crash due to missing error listener on socket

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -86,6 +86,8 @@ var Client = function (options) {
         });
 
         that.socket.on('connect', function () {
+            that.socket.removeAllListeners('error');
+            that.socket.on('error', function (err) { });
             that.connected = true;
             that.socket.setKeepAlive(true, 10000);
         });
@@ -97,7 +99,7 @@ var Client = function (options) {
      * @param {function} cb
      */
     this.queuePush = function (buf, cb) {
-        this.queue.push({buf: buf, callback: cb});
+        this.queue.push({ buf: buf, callback: cb });
         this.queueShift();
     };
 
@@ -106,12 +108,12 @@ var Client = function (options) {
      */
     this.queueShift = function () {
         var timeout;
-        var writeEnd = function () {
+        var writeEnd = function (onError) {
             that.pending = false;
             clearTimeout(timeout);
             that.socket.removeAllListeners('data');
             that.socket.removeAllListeners('timeout');
-            that.socket.removeAllListeners('error');
+            that.socket.removeListener('error', onError);
         };
 
         if (that.queue.length > 0) {
@@ -125,6 +127,11 @@ var Client = function (options) {
                 var length;
 
                 var obj = that.queue.shift();
+                let onError;
+                onError = function (err) {
+                    writeEnd(onError);
+                    obj.callback(err);
+                }
 
                 that.socket.on('data', function (data) {
                     if (chunk === 0) {
@@ -147,27 +154,26 @@ var Client = function (options) {
                     }
                     chunk += 1;
                     if (response.length >= length) {
-                        writeEnd();
+                        writeEnd(onError);
                         if (typeof obj.callback === 'function') {
                             obj.callback(null, response);
                         }
                     }
                 });
-                that.socket.on('error', function (err) {
-                    writeEnd();
-                    obj.callback(err);
-                });
+
+
+                that.socket.on('error', onError);
                 that.socket.on('timeout', function () {
-                    writeEnd();
+                    writeEnd(onError);
                     obj.callback(new Error('socket timeout'));
                 });
                 timeout = setTimeout(function () {
-                    writeEnd();
+                    writeEnd(onError);
                     obj.callback(new Error('response timeout'));
                 }, that.responseTimeout);
                 that.socket.write(obj.buf, function (err) {
                     if (err && typeof obj.callback === 'function') {
-                        writeEnd();
+                        writeEnd(onError);
                         obj.callback(err);
                     }
                 });

--- a/lib/client.js
+++ b/lib/client.js
@@ -87,7 +87,7 @@ var Client = function (options) {
 
         that.socket.on('connect', function () {
             that.socket.removeAllListeners('error');
-            that.socket.on('error', function (err) { });
+            that.socket.on('error', function () { });
             that.connected = true;
             that.socket.setKeepAlive(true, 10000);
         });
@@ -99,7 +99,7 @@ var Client = function (options) {
      * @param {function} cb
      */
     this.queuePush = function (buf, cb) {
-        this.queue.push({ buf: buf, callback: cb });
+        this.queue.push({buf: buf, callback: cb});
         this.queueShift();
     };
 
@@ -131,7 +131,7 @@ var Client = function (options) {
                 onError = function (err) {
                     writeEnd(onError);
                     obj.callback(err);
-                }
+                };
 
                 that.socket.on('data', function (data) {
                     if (chunk === 0) {
@@ -160,7 +160,6 @@ var Client = function (options) {
                         }
                     }
                 });
-
 
                 that.socket.on('error', onError);
                 that.socket.on('timeout', function () {

--- a/lib/client.js
+++ b/lib/client.js
@@ -143,7 +143,7 @@ var Client = function (options) {
                         length = vars.msgSize + 8;
                         response = data;
                         if (vars.head.toString() !== 'Bin') {
-                            writeEnd();
+                            writeEnd(onError);
                             if (typeof obj.callback === 'function') {
                                 obj.callback(new Error('malformed response'));
                             }

--- a/tests/client-server-disconnect.js
+++ b/tests/client-server-disconnect.js
@@ -76,4 +76,17 @@ describe('client server disconnect', function () {
         }, 5000);
 
     });
+
+    it('should handle socket errors after a writeEnd', function (done) {
+        this.timeout(60000);
+        var rpcServer = rpc.createServer({host: '127.0.0.1', port: 2041});
+        var rpcClient = rpc.createClient({host: '127.0.0.1', port: 2041});
+        rpcServer.on('ok', function (err, params, callback) {
+            callback(null, '');
+        });
+        rpcClient.methodCall('ok', [''], function (err, res) {
+            rpcClient.socket.emit('error');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
I ran into an issue where the client crashes due to a missing error event listener on the socket. This happens when the ccu is not reachable and I keep trying to connect. The client uses a timeout and deletes all event listeners if no response is received. This results in a short period where there is no error listener defined and that is not allowed. If now a response comes in during that period then the client crashed.

Here I am now defining an empty function error listener that will always stay configured. The actual error handling is then done with a second listener. During writeEnd I then delete every listener, but not the empty error listener.